### PR TITLE
FIX items description element overflow

### DIFF
--- a/go-order-styles.css
+++ b/go-order-styles.css
@@ -62,6 +62,10 @@ html {
     color: var(--primary-color)
 }
 
+.menu .menu-items .card .card-body {
+    overflow: hidden;
+}
+
 .menu .menu-items .card .card-body .price {
     color: #ffc720;
     text-align: right;


### PR DESCRIPTION
<img width="795" alt="Screenshot 2025-01-25 at 07 25 08" src="https://github.com/user-attachments/assets/309893fd-871b-499d-9a30-ede288dc91ca" />
<img width="794" alt="Screenshot 2025-01-25 at 07 54 54" src="https://github.com/user-attachments/assets/2e004ced-eb35-47f2-b96a-84a6663ed25f" />
